### PR TITLE
Hotfix/outerSolutionReferenceFix

### DIFF
--- a/Borgertinget.sln
+++ b/Borgertinget.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicBackend", "BasicBackend\BasicBackend.csproj", "{5098F5B4-9017-93B9-C3D1-67B581A3021C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "backend", "backend\backend.csproj", "{5098F5B4-9017-93B9-C3D1-67B581A3021C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Small fix for the Solution Referencing fixed. Caused red indicator in VSCode