### PR TITLE
Remove obsolete version attribute from Docker Compose file for backend

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:14


### PR DESCRIPTION
The Docker Compose file for the backend has been updated to remove the obsolete version attribute, streamlining the configuration.

Fixes #16